### PR TITLE
Remove application attributes from manifest

### DIFF
--- a/okhttp3-persistent-cookiejar/src/main/AndroidManifest.xml
+++ b/okhttp3-persistent-cookiejar/src/main/AndroidManifest.xml
@@ -1,12 +1,6 @@
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.franmontiel.persistentcookiejar">
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
For a library there is no need to have these attributes in the application tag and also they could clash with the consumer manifest attributes.