### PR TITLE
Null cookie fix

### DIFF
--- a/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/persistence/SharedPrefsCookiePersistor.java
+++ b/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/persistence/SharedPrefsCookiePersistor.java
@@ -47,7 +47,9 @@ public class SharedPrefsCookiePersistor implements CookiePersistor {
         for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
             String serializedCookie = (String) entry.getValue();
             Cookie cookie = new SerializableCookie().decode(serializedCookie);
-            cookies.add(cookie);
+            if (cookie != null) {
+                cookies.add(cookie);
+            }
         }
         return cookies;
     }


### PR DESCRIPTION
Implement null check when `SerializableCookie.decode()` throws `Exception` and returns `null`.

Should fix #24 