### PR TITLE
Fixes ConcurrentModificationException mentioned in Issue #47

### DIFF
--- a/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/cache/SetCookieCache.java
+++ b/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/cache/SetCookieCache.java
@@ -17,9 +17,10 @@
 package com.franmontiel.persistentcookiejar.cache;
 
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import okhttp3.Cookie;
 
@@ -28,7 +29,7 @@ public class SetCookieCache implements CookieCache {
     private Set<IdentifiableCookie> cookies;
 
     public SetCookieCache() {
-        cookies = new HashSet<>();
+        cookies = Collections.newSetFromMap(new ConcurrentHashMap<IdentifiableCookie, Boolean>());
     }
 
     @Override


### PR DESCRIPTION
This crash was our app's most common crash prior to making this change.

```
Fatal Exception: java.util.ConcurrentModificationException
       at java.util.HashMap$HashIterator.nextEntry(HashMap.java:851)
       at java.util.HashMap$KeyIterator.next(HashMap.java:885)
       at com.franmontiel.persistentcookiejar.cache.SetCookieCache$SetCookieCacheIterator.next(SetCookieCache.java:67)
       at com.franmontiel.persistentcookiejar.cache.SetCookieCache$SetCookieCacheIterator.next(SetCookieCache.java:52)
```
After this change, we've had zero ConcurrentModificationExceptions and our crash-free sessions are up to over 99%.

Hashset is not thread-safe and the use of the `synchronized` keyword was still allowing the crash to happen in the iterator's `next()` method.

We are using this fork in our production app with no issues.