### PR TITLE
Fix NPE in SerializableCookie

### DIFF
--- a/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/persistence/SharedPrefsCookiePersistor.java
+++ b/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/persistence/SharedPrefsCookiePersistor.java
@@ -46,6 +46,9 @@ public class SharedPrefsCookiePersistor implements CookiePersistor {
 
         for (Map.Entry<String, ?> entry : sharedPreferences.getAll().entrySet()) {
             String serializedCookie = (String) entry.getValue();
+            if (serializedCookie == null) {
+                continue;
+            }
             Cookie cookie = new SerializableCookie().decode(serializedCookie);
             if (cookie != null) {
                 cookies.add(cookie);


### PR DESCRIPTION
There is an NPE in com.franmontiel.persistentcookiejar.persistence.SerializableCookie.hexStringToByteArray (SerializableCookie.java:117)
caused by the fact that SharedPreferences return nullable value.