### PR TITLE
Update IdentifiableCookie.java

### DIFF
--- a/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/cache/IdentifiableCookie.java
+++ b/okhttp3-persistent-cookiejar/src/main/java/com/franmontiel/persistentcookiejar/cache/IdentifiableCookie.java
@@ -55,7 +55,6 @@ class IdentifiableCookie {
         return that.cookie.name().equals(this.cookie.name())
                 && that.cookie.domain().equals(this.cookie.domain())
                 && that.cookie.path().equals(this.cookie.path())
-                && that.cookie.secure() == this.cookie.secure()
                 && that.cookie.hostOnly() == this.cookie.hostOnly();
     }
 
@@ -65,7 +64,6 @@ class IdentifiableCookie {
         hash = 31 * hash + cookie.name().hashCode();
         hash = 31 * hash + cookie.domain().hashCode();
         hash = 31 * hash + cookie.path().hashCode();
-        hash = 31 * hash + (cookie.secure() ? 0 : 1);
         hash = 31 * hash + (cookie.hostOnly() ? 0 : 1);
         return hash;
     }


### PR DESCRIPTION
Skip secure flag check on equals and hashCode generation.

My problem was that a server sent a set-cookie with "secure" and "HttpOnly" flags, then later after logout it sent a similar set-cookie without those flags.

The "SetCookieCache" java class then had it duplicated in the cookies Set (it should have replace the old one).

I wrote a PHP script to test how chrome handling this (i used https for the tests to be sure):
```php
<?php
$iter = $_GET['iter'] ?? 1;

if ($iter == 1) { 
    setcookie('cookie_test_s_h', 'test', time() + 3600, '/', '', true, true);
    setcookie('cookie_test_s', 'test', time() + 3600, '/', '', true, false);
    setcookie('cookie_test_h', 'test', time() + 3600, '/', '', false, true);
    header('Location: ?iter=2');
} else if ($iter == 2) {
    // exit; 
    setcookie('cookie_test_s_h', 'empty', time() + 3600, '/', '', false, false);
    setcookie('cookie_test_s', 'empty', time() + 3600, '/', '', false, false);
    setcookie('cookie_test_h', 'empty', time() + 3600, '/', '', false, false);
    header('Location: ?iter=3');
} else { 
    echo 'Done';
}
```
After the first iteration:
![image](https://user-images.githubusercontent.com/7146902/57943066-65a11980-78d3-11e9-9327-8ab7b2301537.png)

After the second iteration I got the result what I expected:
![image](https://user-images.githubusercontent.com/7146902/57942655-55d50580-78d2-11e9-9e2c-a7e580bb156a.png)

### TL;DR
This commit fixes the duplicate cookie problem what happens when the following situation happens:


`set-cookie: as=SOME_TOKEN_HERE; expires=Fri, 17-May-2019 16:17:01 GMT; path=/; secure; HttpOnly`
`set-cookie: as=; expires=Thu, 16-May-2019 16:12:02 GMT; path=/`